### PR TITLE
Accounting for bad k8s deployments

### DIFF
--- a/src/main/groovy/io/cratekube/lifecycle/api/ComponentApi.groovy
+++ b/src/main/groovy/io/cratekube/lifecycle/api/ComponentApi.groovy
@@ -13,6 +13,8 @@ interface ComponentApi {
   /**
    * Retrieves the CrateKube component specified by name.
    * Returns null if component is not deployed and does not have released version in GitHub.
+   * <p>
+   *   {@link Component#currentVersion} is null if no pods are running and ready.
    *
    * @param name {@code non-empty} component name
    * @return the component

--- a/src/test/groovy/io/cratekube/lifecycle/service/ComponentServiceSpec.groovy
+++ b/src/test/groovy/io/cratekube/lifecycle/service/ComponentServiceSpec.groovy
@@ -63,7 +63,15 @@ class ComponentServiceSpec extends Specification {
                           "spec": {
                               "containers": [
                                   {
-                                      "image": "dockerhub.cisco.com\/crate-docker\/lifecycle-service:${curVersion}"
+                                      "name": "${nm}",
+                                      "image": "cratekube\/${nm}:${curVersion}"
+                                  }
+                              ]
+                          },
+                          "status": {
+                              "conditions": [
+                                  {
+                                      "status": "True"
                                   }
                               ]
                           }
@@ -72,6 +80,66 @@ class ComponentServiceSpec extends Specification {
               }/.stripMargin()
     kubectlApi.getPodJsonByNameSelector(nm) >> cfg
     def latVersion = '1.0.1'
+    gitHubApi.getLatestVersionFromAtomFeed(nm) >> latVersion
+
+    when:
+    def result = subject.getComponent(nm)
+
+    then:
+    expect result, notNullValue()
+    verifyAll(result) {
+      expect name, equalTo(nm)
+      expect config, equalTo(cfg)
+      expect currentVersion, equalTo(curVersion)
+      expect latestVersion, equalTo(latVersion)
+    }
+  }
+
+  def 'getComponent should retrieve and return ready component as current version'() {
+    given:
+    //defaults to empty cache
+    def nm = 'test-name'
+    def curVersion = '1.0.0'
+    def latVersion = '1.0.1'
+    def cfg = /{
+                  "items": [
+                      {
+                          "spec": {
+                              "containers": [
+                                  {
+                                      "name": "${nm}",
+                                      "image": "cratekube\/${nm}:${latVersion}"
+                                  }
+                              ]
+                          },
+                          "status": {
+                              "conditions": [
+                                  {
+                                      "status": "False"
+                                  }
+                              ]
+                          }
+                      },
+                      {
+                          "spec": {
+                              "containers": [
+                                  {
+                                      "name": "${nm}",
+                                      "image": "cratekube\/${nm}:${curVersion}"
+                                  }
+                              ]
+                          },
+                          "status": {
+                              "conditions": [
+                                  {
+                                      "status": "True"
+                                  }
+                              ]
+                          }
+                      }
+                  ]
+              }/.stripMargin()
+    kubectlApi.getPodJsonByNameSelector(nm) >> cfg
     gitHubApi.getLatestVersionFromAtomFeed(nm) >> latVersion
 
     when:
@@ -144,7 +212,15 @@ class ComponentServiceSpec extends Specification {
                           "spec": {
                               "containers": [
                                   {
-                                      "image": "dockerhub.cisco.com\/crate-docker\/lifecycle-service:${curVersion}"
+                                      "name": "${name}",
+                                      "image": "cratekube\/${name}:${curVersion}"
+                                  }
+                              ]
+                          },
+                          "status": {
+                              "conditions": [
+                                  {
+                                      "status": "True"
                                   }
                               ]
                           }


### PR DESCRIPTION
Signed-off-by: Daniel Foglio <dfoglio@cisco.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cratekube/lifecycle-service/9)
<!-- Reviewable:end -->
